### PR TITLE
Remove some rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.1.0
+
+- Remove stylelint-order plugin
+- Remove `max-empty-lines` rule
+
 ## v2.0.0
 
 - Add stylelint-csstree-validator plugin.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   "plugins": [
-    "stylelint-csstree-validator",
-    "stylelint-order",
+    "stylelint-csstree-validator"
   ],
   "rules": {
     "at-rule-no-vendor-prefix": true,
@@ -48,9 +47,6 @@ module.exports = {
     "value-no-vendor-prefix": true,
 
     // stylelint-csstree-validator
-    "csstree/validator": true,
-
-    // stylelint-order
-    "order/properties-order": require('./properties-order'),
+    "csstree/validator": true
   },
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = {
     "indentation": 2,
     "keyframe-declaration-no-important": true,
     "length-zero-no-unit": true,
-    "max-empty-lines": 1,
     "media-feature-name-case": "lower",
     "media-feature-name-no-vendor-prefix": true,
     "no-empty-source": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "stylelint": "^7.10.1"
   },
   "dependencies": {
-    "stylelint-csstree-validator": "^1.1.1",
-    "stylelint-order": "^0.4.3"
+    "stylelint-csstree-validator": "^1.1.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,6 @@ test("a warning with invalid css", t => {
     const { errored, results } = data;
     const { warnings } = results[0];
     t.truthy(errored, "errored");
-    t.is(warnings.length, 132, "flags 132 warning");
+    t.is(warnings.length, 72, "flags 72 warning");
   });
 });


### PR DESCRIPTION
## What

- Remove stylelint-order plugin
- Remove `max-empty-lines` rule

## Why

I don't care specific properties order when I'm writing code, tho we have better to sort properties before gzip to increase compressibility.

I think, whitespace can be semantic. As well as being useful for glancing at files, whitespace can also provide actual meaning.
